### PR TITLE
Fix Auto Packing not work

### DIFF
--- a/src/main/java/net/chauvedev/woodencog/mixin/blockEnitites/MixinBasinOperatingBlockEntity.java
+++ b/src/main/java/net/chauvedev/woodencog/mixin/blockEnitites/MixinBasinOperatingBlockEntity.java
@@ -4,9 +4,6 @@ import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import com.simibubi.create.content.processing.basin.BasinOperatingBlockEntity;
 import com.simibubi.create.content.processing.basin.BasinRecipe;
-import com.simibubi.create.foundation.advancement.CreateAdvancement;
-import com.simibubi.create.foundation.recipe.RecipeFinder;
-import net.chauvedev.woodencog.WoodenCog;
 import net.chauvedev.woodencog.recipes.heatedRecipes.recipes.HeatedBasinRecipe;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Container;
@@ -14,18 +11,16 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Comparator;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Mixin(value = BasinOperatingBlockEntity.class, remap = false)
 public abstract class MixinBasinOperatingBlockEntity extends KineticBlockEntity {
@@ -33,19 +28,11 @@ public abstract class MixinBasinOperatingBlockEntity extends KineticBlockEntity 
         super(typeIn, pos, state);
     }
 
-    /**
-     * @author ChauveDev
-     * @reason This function didn't take in account the fluid ingredients which is pretty bad in a basin
-     */
-    @Overwrite
-    protected List<Recipe<?>> getMatchingRecipes() {
-        if (this.getBasin().map(BasinBlockEntity::isEmpty).orElse(true)) {
-            return new ArrayList<>();
-        } else {
-            List<Recipe<?>> list = RecipeFinder.get(this.getRecipeCacheKey(), this.level, this::matchStaticFilters);
-            list = list.stream().filter(this::matchBasinRecipe).sorted(this::woodencog$testFluids).collect(Collectors.toList());
-            return list;
-        }
+    @ModifyArg(method = "getMatchingRecipes",
+            at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;sorted(Ljava/util/Comparator;)Ljava/util/stream/Stream;"),
+            index = 0)
+    protected Comparator<? super Recipe<?>> getMatchingRecipes(Comparator<? super Recipe<?>> comparator) {
+        return this::woodencog$testFluids;
     }
 
     //Add heated and normal test
@@ -69,66 +56,31 @@ public abstract class MixinBasinOperatingBlockEntity extends KineticBlockEntity 
         return 0;
     }
 
-    /**
-     * @author Manwe
-     * @implNote Add call to HeatedBasinRecipe.apply() if necessary, if not continue
-     */
-    @Inject(
+    @Redirect(
             method = "applyBasinRecipe",
-            at = @At("HEAD"),
-            cancellable = true
+            at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/processing/basin/BasinRecipe;apply(Lcom/simibubi/create/content/processing/basin/BasinBlockEntity;Lnet/minecraft/world/item/crafting/Recipe;)Z")
     )
-    protected void applyBasinRecipe(CallbackInfo ci) {
-        if (this.currentRecipe != null && this.currentRecipe instanceof HeatedBasinRecipe heatedBasinRecipe) {
-            Optional<BasinBlockEntity> optionalBasin = this.getBasin();
-            if (optionalBasin.isPresent()) {
-                BasinBlockEntity basin = optionalBasin.get();
-                boolean wasEmpty = basin.canContinueProcessing();
-                if (HeatedBasinRecipe.apply(basin, heatedBasinRecipe)) {
-                    this.invokeGetProceededRecipeTrigger().ifPresent(this::award);
-                    basin.inputTank.sendDataImmediately();
-                    if (wasEmpty && this.matchBasinRecipe(heatedBasinRecipe)) {
-                        this.invokeContinueWithPreviousRecipe();
-                        this.sendData();
-                    }
-
-                    basin.notifyChangeOfContents();
-                }
-            }
-            ci.cancel();
+    protected boolean applyBasinRecipe(BasinBlockEntity basin, Recipe<?> recipe) {
+        if (recipe instanceof HeatedBasinRecipe) {
+            return HeatedBasinRecipe.apply(basin, recipe);
+        } else {
+            return BasinRecipe.apply(basin, recipe);
         }
     }
-
-    @Invoker("getProcessedRecipeTrigger")
-    protected abstract Optional<CreateAdvancement> invokeGetProceededRecipeTrigger();
-
-    @Invoker("continueWithPreviousRecipe")
-    public abstract boolean invokeContinueWithPreviousRecipe();
 
     @Shadow protected Recipe<?> currentRecipe;
 
     @Shadow protected abstract boolean matchStaticFilters(Recipe<?> recipe);
 
-    /**
-     * @author Manwe
-     * @reason Mange BasinRecipe.match and HeatedBasinRecipe.match calls
-     */
-    @Overwrite
-    protected <C extends Container> boolean matchBasinRecipe(Recipe<C> recipe) {
-        if (recipe == null) {
-            return false;
-        }
+    @Inject(method = "matchBasinRecipe",
+            at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/processing/basin/BasinRecipe;match(Lcom/simibubi/create/content/processing/basin/BasinBlockEntity;Lnet/minecraft/world/item/crafting/Recipe;)Z"),
+            cancellable = true)
+    private <C extends Container> void matchHeatBasinRecipe(Recipe<C> recipe, CallbackInfoReturnable<Boolean> cir) {
         Optional<BasinBlockEntity> basin = this.getBasin();
-        if(basin.isEmpty()) return false;
+        assert basin.isPresent();
         if (recipe instanceof HeatedBasinRecipe){
-            //WoodenCog.LOGGER.info("HeatedBasinRecipe matchBasinRecipe");
-            return HeatedBasinRecipe.match(basin.get(),recipe);
+            cir.setReturnValue(HeatedBasinRecipe.match(basin.get(),recipe));
         }
-        if(recipe instanceof BasinRecipe){
-            //WoodenCog.LOGGER.info("BasinRecipe matchBasinRecipe");
-            return BasinRecipe.match(basin.get(),recipe);
-        }
-        return false;
     }
 
     @Shadow()


### PR DESCRIPTION
The original mixin's matchBasinRecipe ignored the case where the recipe was a ShapedCrafting recipe, causing Auto Packing to not work. This PR fixes this issue while also changing the Overwrite to other injection annotations.